### PR TITLE
Specify UTF-8 charset in CSS

### DIFF
--- a/relaxngui.css
+++ b/relaxngui.css
@@ -35,7 +35,7 @@
   cursor: pointer;
 }
 .relaxngui_table.closed .relaxngui_fold:after {
-  content: "\25B6"; /* ▶ */
+  content: "▶";
   font-weight: bold;
   vertical-align:top;
   margin-right: 0.5em;
@@ -43,7 +43,7 @@
   top: -0.13em;
 }
 .relaxngui_table .relaxngui_fold:after {
-  content: "\25BD"; /* ▽ */
+  content: "▽";
   font-weight: bold;
   vertical-align:top;
   margin-right: 0.5em;
@@ -136,7 +136,7 @@
   padding-left: 0.2em;
 }
 .relaxngui_hint::before {
-  content: "\21B3 "; /* ↳ */
+ 	content: "↳ ";
 }
 .relaxngui_header {
   margin: 0;

--- a/relaxngui.css
+++ b/relaxngui.css
@@ -15,6 +15,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
+@charset "UTF-8";
+
 /* if first thing is a header */
 .relaxngui_table[data-relaxngui-level="0"] .relaxngui_table[data-relaxngui-level="1"]:first-child .relaxngui_header[data-relaxngui-level="1"]:first-child {
   padding-top: 0;
@@ -34,7 +36,7 @@
   cursor: pointer;
 }
 .relaxngui_table.closed .relaxngui_fold:after {
-  content: "▶";
+  content: "\25B6"; /* ▶ */
   font-weight: bold;
   vertical-align:top;
   margin-right: 0.5em;
@@ -42,7 +44,7 @@
   top: -0.13em;
 }
 .relaxngui_table .relaxngui_fold:after {
-  content: "▽";
+  content: "\25BD"; /* ▽ */
   font-weight: bold;
   vertical-align:top;
   margin-right: 0.5em;
@@ -135,7 +137,7 @@
   padding-left: 0.2em;
 }
 .relaxngui_hint::before {
- 	content: "↳ ";
+  content: "\21B3 "; /* ↳ */
 }
 .relaxngui_header {
   margin: 0;

--- a/relaxngui.css
+++ b/relaxngui.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /*
   This file is part of RelaxNGui.
 
@@ -14,8 +15,6 @@
   RelaxNGui (file COPYING in the main directory).  If not, see
   <http://www.gnu.org/licenses/>.
 */
-
-@charset "UTF-8";
 
 /* if first thing is a header */
 .relaxngui_table[data-relaxngui-level="0"] .relaxngui_table[data-relaxngui-level="1"]:first-child .relaxngui_header[data-relaxngui-level="1"]:first-child {


### PR DESCRIPTION
Hopefully fixes Chrome messing up the icons from time to time when the file is cached

See https://github.com/etm/uidash.js/pull/1